### PR TITLE
Fix: Error when saving Footer

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -195,14 +195,6 @@ class Footer(Model):
     def __str__(self):
         return self.title
 
-    def save(self, *args, **kwargs):
-        if self.active:
-            for footer in Footer.objects.filter(active=True):
-                footer.active = False
-                footer.save()
-
-        return super(Footer, self).save(*args, **kwargs)
-
 
 class CustomPage(Page):
     footer = ForeignKey(


### PR DESCRIPTION
- Remove unneeded #save method since `active` isn't used anymore
