### PR TITLE
Remove container around navbar for more room for items

### DIFF
--- a/common/templates/common/header.html
+++ b/common/templates/common/header.html
@@ -1,6 +1,5 @@
 <!-- BEGIN HEADER -->
 <div class="header navbar navbar-default navbar-default-top" id="blue-nav">
-    <div class="container">
     <div class="row">
         <div class="navbar-header col-md-4">
             <!-- BEGIN RESPONSIVE MENU TOGGLER -->
@@ -85,6 +84,5 @@
             {% include "common/blocks/search_box.html" only %}
         {% endblock %}
     </div>
-</div>
 </div>
 <!-- END HEADER -->


### PR DESCRIPTION
Removes some of the padding a `container` adds in favor of using the space.

![screen shot 2016-10-28 at 1 40 52 pm](https://cloud.githubusercontent.com/assets/8905795/19816194/56dca9de-9d14-11e6-889f-741df1680a1a.png)

Closes #128 
